### PR TITLE
chore: add deploy flow

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  high_level_summary: false

--- a/.github/workflows/lighthouse-preview.yml
+++ b/.github/workflows/lighthouse-preview.yml
@@ -72,7 +72,7 @@ jobs:
                   const hasPagesUrl = (comment.body ?? "").includes(".pages.dev");
                   return [
                     `id=${comment.id}`,
-                    `author=${comment.user.login}`,
+                    `author=${comment.user?.login}`,
                     `updated=${comment.updated_at}`,
                     `hasPagesUrl=${hasPagesUrl}`,
                   ].join(" ");
@@ -97,7 +97,7 @@ jobs:
               }
 
               const cloudflareComments = comments
-                .filter((comment) => comment.user.login === cloudflareBotLogin)
+                .filter((comment) => comment.user?.login === cloudflareBotLogin)
                 .sort((left, right) => new Date(right.updated_at) - new Date(left.updated_at));
 
               core.info(`Attempt ${attempt}: found ${cloudflareComments.length} Cloudflare comments.`);
@@ -145,28 +145,41 @@ jobs:
           npx --yes lighthouse@13.1.0 "${PREVIEW_URL}" \
             --only-categories=performance,accessibility,best-practices,seo \
             --output=json \
-            --output-path=.tmp/lighthouse/report.json \
+            --output=html \
+            --output-path=.tmp/lighthouse/report \
             --chrome-flags="--headless=new --no-sandbox --disable-dev-shm-usage"
         env:
           PREVIEW_URL: ${{ steps.preview.outputs.url }}
 
+      - name: Upload Lighthouse report
+        id: upload-report
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report-${{ github.event.pull_request.number }}
+          path: .tmp/lighthouse/
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Comment Lighthouse score
         uses: actions/github-script@v7
         env:
+          ARTIFACT_URL: ${{ steps.upload-report.outputs.artifact-url }}
           PREVIEW_URL: ${{ steps.preview.outputs.url }}
         with:
           script: |
             const fs = require("node:fs");
             const {owner, repo} = context.repo;
             const issue_number = context.payload.pull_request.number;
-            const report = JSON.parse(fs.readFileSync(".tmp/lighthouse/report.json", "utf8"));
+            const report = JSON.parse(
+              fs.readFileSync(".tmp/lighthouse/report.report.json", "utf8"),
+            );
             const marker = "<!-- lighthouse-preview-report -->";
             const score = (category) => Math.round(report.categories[category].score * 100);
             const displayValue = (auditId) => report.audits[auditId]?.displayValue ?? "n/a";
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const artifactUrl = process.env.ARTIFACT_URL;
 
-            const body = [
-              marker,
+            const summary = [
               "## Lighthouse Preview",
               "",
               `Target: ${process.env.PREVIEW_URL}`,
@@ -186,8 +199,16 @@ jobs:
               `| Cumulative Layout Shift | ${displayValue("cumulative-layout-shift")} |`,
               `| Speed Index | ${displayValue("speed-index")} |`,
               "",
+              `[Lighthouse report artifact](${artifactUrl})`,
               `[Workflow run](${runUrl})`,
             ].join("\n");
+
+            const body = [
+              marker,
+              summary,
+            ].join("\n");
+
+            await fs.promises.appendFile(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
@@ -197,7 +218,7 @@ jobs:
             });
 
             const existingComment = comments.find((comment) => {
-              return comment.user.type === "Bot" && comment.body.includes(marker);
+              return comment.user?.type === "Bot" && comment.body.includes(marker);
             });
 
             if (existingComment) {

--- a/.github/workflows/lighthouse-preview.yml
+++ b/.github/workflows/lighthouse-preview.yml
@@ -44,8 +44,14 @@ jobs:
               /<strong>Preview URL:<\/strong><\/td><td>[\s\S]*?<a href=['"]([^'"]+\.pages\.dev)['"]/i;
             const deadline = Date.now() + 10 * 60 * 1000;
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            let attempt = 0;
+
+            core.info(`Looking for Cloudflare Pages preview comment on PR #${issue_number}.`);
+            core.info(`Expected head SHA: ${headSha}`);
+            core.info(`Expected bot login: ${cloudflareBot}`);
 
             async function findPreviewUrlFromCloudflareComment() {
+              attempt += 1;
               const comments = await github.paginate(github.rest.issues.listComments, {
                 owner,
                 repo,
@@ -53,9 +59,29 @@ jobs:
                 per_page: 100,
               });
 
+              core.info(`Attempt ${attempt}: fetched ${comments.length} PR comments.`);
+              const recentCommentSummary = comments
+                .slice(-10)
+                .map((comment) => {
+                  const hasPagesUrl = (comment.body ?? "").includes(".pages.dev");
+                  return [
+                    `id=${comment.id}`,
+                    `author=${comment.user.login}`,
+                    `updated=${comment.updated_at}`,
+                    `hasPagesUrl=${hasPagesUrl}`,
+                  ].join(" ");
+                })
+                .join("\n");
+
+              if (recentCommentSummary) {
+                core.info(`Attempt ${attempt}: recent comments:\n${recentCommentSummary}`);
+              }
+
               const cloudflareComments = comments
                 .filter((comment) => comment.user.login === cloudflareBot)
                 .sort((left, right) => new Date(right.updated_at) - new Date(left.updated_at));
+
+              core.info(`Attempt ${attempt}: found ${cloudflareComments.length} Cloudflare comments.`);
 
               for (const comment of cloudflareComments) {
                 const body = comment.body ?? "";
@@ -64,6 +90,17 @@ jobs:
                 const isCurrentHead = latestCommit && headSha.startsWith(latestCommit);
                 const isSuccessful = body.includes("Deploy successful");
                 const previewUrl = body.match(previewUrlPattern)?.[1] ?? "";
+
+                core.info(
+                  [
+                    `Attempt ${attempt}: inspect Cloudflare comment id=${comment.id}`,
+                    `updated=${comment.updated_at}`,
+                    `latestCommit=${latestCommit || "(not found)"}`,
+                    `isCurrentHead=${Boolean(isCurrentHead)}`,
+                    `isSuccessful=${isSuccessful}`,
+                    `previewUrl=${previewUrl || "(not found)"}`,
+                  ].join(" "),
+                );
 
                 if (isCurrentHead && isSuccessful && previewUrl) {
                   return previewUrl;

--- a/.github/workflows/lighthouse-preview.yml
+++ b/.github/workflows/lighthouse-preview.yml
@@ -39,7 +39,10 @@ jobs:
             const pullRequest = context.payload.pull_request;
             const headSha = pullRequest.head.sha;
             const issue_number = pullRequest.number;
-            const cloudflareBot = "cloudflare-workers-and-pages";
+            const cloudflareBotLogins = new Set([
+              "cloudflare-workers-and-pages",
+              "cloudflare-workers-and-pages[bot]",
+            ]);
             const previewUrlPattern =
               /<strong>Preview URL:<\/strong><\/td><td>[\s\S]*?<a href=['"]([^'"]+\.pages\.dev)['"]/i;
             const deadline = Date.now() + 10 * 60 * 1000;
@@ -48,7 +51,7 @@ jobs:
 
             core.info(`Looking for Cloudflare Pages preview comment on PR #${issue_number}.`);
             core.info(`Expected head SHA: ${headSha}`);
-            core.info(`Expected bot login: ${cloudflareBot}`);
+            core.info(`Expected bot login: ${Array.from(cloudflareBotLogins).join(" or ")}`);
 
             async function findPreviewUrlFromCloudflareComment() {
               attempt += 1;
@@ -58,6 +61,8 @@ jobs:
                 issue_number,
                 per_page: 100,
               });
+
+              core.info(`comments: ${JSON.stringify(comments, null, 2)}`);
 
               core.info(`Attempt ${attempt}: fetched ${comments.length} PR comments.`);
               const recentCommentSummary = comments
@@ -78,7 +83,7 @@ jobs:
               }
 
               const cloudflareComments = comments
-                .filter((comment) => comment.user.login === cloudflareBot)
+                .filter((comment) => cloudflareBotLogins.has(comment.user.login))
                 .sort((left, right) => new Date(right.updated_at) - new Date(left.updated_at));
 
               core.info(`Attempt ${attempt}: found ${cloudflareComments.length} Cloudflare comments.`);

--- a/.github/workflows/lighthouse-preview.yml
+++ b/.github/workflows/lighthouse-preview.yml
@@ -1,0 +1,176 @@
+name: Lighthouse Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+
+concurrency:
+  group: lighthouse-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  deployments: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  lighthouse:
+    name: Lighthouse preview
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Find Cloudflare Pages preview URL
+        id: preview
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const pullRequest = context.payload.pull_request;
+            const headSha = pullRequest.head.sha;
+            const headRef = pullRequest.head.ref;
+            const markerHost = ".pages.dev";
+            const deadline = Date.now() + 20 * 60 * 1000;
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+            async function findPreviewUrl(ref) {
+              const deployments = await github.paginate(github.rest.repos.listDeployments, {
+                owner,
+                repo,
+                ref,
+                per_page: 100,
+              });
+
+              const sortedDeployments = deployments.sort(
+                (left, right) => new Date(right.created_at) - new Date(left.created_at),
+              );
+
+              for (const deployment of sortedDeployments) {
+                if (deployment.sha !== headSha) {
+                  continue;
+                }
+
+                const statuses = await github.paginate(github.rest.repos.listDeploymentStatuses, {
+                  owner,
+                  repo,
+                  deployment_id: deployment.id,
+                  per_page: 100,
+                });
+
+                const successStatus = statuses
+                  .sort((left, right) => new Date(right.created_at) - new Date(left.created_at))
+                  .find((status) => {
+                    const url = status.environment_url || status.target_url || "";
+                    return status.state === "success" && url.includes(markerHost);
+                  });
+
+                if (successStatus) {
+                  return successStatus.environment_url || successStatus.target_url;
+                }
+              }
+
+              return "";
+            }
+
+            while (Date.now() < deadline) {
+              const previewUrl = (await findPreviewUrl(headSha)) || (await findPreviewUrl(headRef));
+
+              if (previewUrl) {
+                core.info(`Found preview URL: ${previewUrl}`);
+                core.setOutput("url", previewUrl);
+                return;
+              }
+
+              core.info("Cloudflare Pages preview URL is not ready yet. Waiting...");
+              await sleep(15 * 1000);
+            }
+
+            core.setFailed("Cloudflare Pages preview URL was not found within 20 minutes.");
+
+      - name: Run Lighthouse
+        run: |
+          mkdir -p .tmp/lighthouse
+          npx --yes lighthouse@13.1.0 "${PREVIEW_URL}" \
+            --only-categories=performance,accessibility,best-practices,seo \
+            --output=json \
+            --output-path=.tmp/lighthouse/report.json \
+            --chrome-flags="--headless=new --no-sandbox --disable-dev-shm-usage"
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.url }}
+
+      - name: Comment Lighthouse score
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.url }}
+        with:
+          script: |
+            const fs = require("node:fs");
+            const {owner, repo} = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const report = JSON.parse(fs.readFileSync(".tmp/lighthouse/report.json", "utf8"));
+            const marker = "<!-- lighthouse-preview-report -->";
+            const score = (category) => Math.round(report.categories[category].score * 100);
+            const displayValue = (auditId) => report.audits[auditId]?.displayValue ?? "n/a";
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            const body = [
+              marker,
+              "## Lighthouse Preview",
+              "",
+              `Target: ${process.env.PREVIEW_URL}`,
+              "",
+              "| Category | Score |",
+              "| --- | ---: |",
+              `| Performance | ${score("performance")} |`,
+              `| Accessibility | ${score("accessibility")} |`,
+              `| Best Practices | ${score("best-practices")} |`,
+              `| SEO | ${score("seo")} |`,
+              "",
+              "| Metric | Value |",
+              "| --- | ---: |",
+              `| First Contentful Paint | ${displayValue("first-contentful-paint")} |`,
+              `| Largest Contentful Paint | ${displayValue("largest-contentful-paint")} |`,
+              `| Total Blocking Time | ${displayValue("total-blocking-time")} |`,
+              `| Cumulative Layout Shift | ${displayValue("cumulative-layout-shift")} |`,
+              `| Speed Index | ${displayValue("speed-index")} |`,
+              "",
+              `[Workflow run](${runUrl})`,
+            ].join("\n");
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existingComment = comments.find((comment) => {
+              return comment.user.type === "Bot" && comment.body.includes(marker);
+            });
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/lighthouse-preview.yml
+++ b/.github/workflows/lighthouse-preview.yml
@@ -14,7 +14,6 @@ concurrency:
 
 permissions:
   contents: read
-  deployments: read
   issues: write
   pull-requests: read
 
@@ -39,44 +38,35 @@ jobs:
             const {owner, repo} = context.repo;
             const pullRequest = context.payload.pull_request;
             const headSha = pullRequest.head.sha;
-            const headRef = pullRequest.head.ref;
-            const markerHost = ".pages.dev";
-            const deadline = Date.now() + 20 * 60 * 1000;
+            const issue_number = pullRequest.number;
+            const cloudflareBot = "cloudflare-workers-and-pages";
+            const previewUrlPattern =
+              /<strong>Preview URL:<\/strong><\/td><td>[\s\S]*?<a href=['"]([^'"]+\.pages\.dev)['"]/i;
+            const deadline = Date.now() + 10 * 60 * 1000;
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-            async function findPreviewUrl(ref) {
-              const deployments = await github.paginate(github.rest.repos.listDeployments, {
+            async function findPreviewUrlFromCloudflareComment() {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner,
                 repo,
-                ref,
+                issue_number,
                 per_page: 100,
               });
 
-              const sortedDeployments = deployments.sort(
-                (left, right) => new Date(right.created_at) - new Date(left.created_at),
-              );
+              const cloudflareComments = comments
+                .filter((comment) => comment.user.login === cloudflareBot)
+                .sort((left, right) => new Date(right.updated_at) - new Date(left.updated_at));
 
-              for (const deployment of sortedDeployments) {
-                if (deployment.sha !== headSha) {
-                  continue;
-                }
+              for (const comment of cloudflareComments) {
+                const body = comment.body ?? "";
+                const commitMatch = body.match(/<code>([0-9a-f]{7,40})<\/code>/i);
+                const latestCommit = commitMatch?.[1] ?? "";
+                const isCurrentHead = latestCommit && headSha.startsWith(latestCommit);
+                const isSuccessful = body.includes("Deploy successful");
+                const previewUrl = body.match(previewUrlPattern)?.[1] ?? "";
 
-                const statuses = await github.paginate(github.rest.repos.listDeploymentStatuses, {
-                  owner,
-                  repo,
-                  deployment_id: deployment.id,
-                  per_page: 100,
-                });
-
-                const successStatus = statuses
-                  .sort((left, right) => new Date(right.created_at) - new Date(left.created_at))
-                  .find((status) => {
-                    const url = status.environment_url || status.target_url || "";
-                    return status.state === "success" && url.includes(markerHost);
-                  });
-
-                if (successStatus) {
-                  return successStatus.environment_url || successStatus.target_url;
+                if (isCurrentHead && isSuccessful && previewUrl) {
+                  return previewUrl;
                 }
               }
 
@@ -84,7 +74,7 @@ jobs:
             }
 
             while (Date.now() < deadline) {
-              const previewUrl = (await findPreviewUrl(headSha)) || (await findPreviewUrl(headRef));
+              const previewUrl = await findPreviewUrlFromCloudflareComment();
 
               if (previewUrl) {
                 core.info(`Found preview URL: ${previewUrl}`);
@@ -92,11 +82,11 @@ jobs:
                 return;
               }
 
-              core.info("Cloudflare Pages preview URL is not ready yet. Waiting...");
+              core.info("Cloudflare Pages comment is not ready yet. Waiting...");
               await sleep(15 * 1000);
             }
 
-            core.setFailed("Cloudflare Pages preview URL was not found within 20 minutes.");
+            core.setFailed("Cloudflare Pages preview URL comment was not found within 10 minutes.");
 
       - name: Run Lighthouse
         run: |

--- a/.github/workflows/lighthouse-preview.yml
+++ b/.github/workflows/lighthouse-preview.yml
@@ -15,7 +15,7 @@ concurrency:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   lighthouse:
@@ -39,10 +39,7 @@ jobs:
             const pullRequest = context.payload.pull_request;
             const headSha = pullRequest.head.sha;
             const issue_number = pullRequest.number;
-            const cloudflareBotLogins = new Set([
-              "cloudflare-workers-and-pages",
-              "cloudflare-workers-and-pages[bot]",
-            ]);
+            const cloudflareBotLogin = "cloudflare-workers-and-pages[bot]";
             const previewUrlPattern =
               /<strong>Preview URL:<\/strong><\/td><td>[\s\S]*?<a href=['"]([^'"]+\.pages\.dev)['"]/i;
             const deadline = Date.now() + 10 * 60 * 1000;
@@ -51,21 +48,25 @@ jobs:
 
             core.info(`Looking for Cloudflare Pages preview comment on PR #${issue_number}.`);
             core.info(`Expected head SHA: ${headSha}`);
-            core.info(`Expected bot login: ${Array.from(cloudflareBotLogins).join(" or ")}`);
+            core.info(`Expected bot login: ${cloudflareBotLogin}`);
 
-            async function findPreviewUrlFromCloudflareComment() {
-              attempt += 1;
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner,
-                repo,
-                issue_number,
-                per_page: 100,
-              });
+            function parseCloudflareComment(comment) {
+              const body = comment.body ?? "";
+              const commitMatch = body.match(/<code>([0-9a-f]{7,40})<\/code>/i);
+              const latestCommit = commitMatch?.[1] ?? "";
 
-              core.info(`comments: ${JSON.stringify(comments, null, 2)}`);
+              return {
+                id: comment.id,
+                updatedAt: comment.updated_at,
+                latestCommit,
+                isCurrentHead: Boolean(latestCommit && headSha.startsWith(latestCommit)),
+                isSuccessful: body.includes("Deploy successful"),
+                previewUrl: body.match(previewUrlPattern)?.[1] ?? "",
+              };
+            }
 
-              core.info(`Attempt ${attempt}: fetched ${comments.length} PR comments.`);
-              const recentCommentSummary = comments
+            function summarizeRecentComments(comments) {
+              return comments
                 .slice(-10)
                 .map((comment) => {
                   const hasPagesUrl = (comment.body ?? "").includes(".pages.dev");
@@ -77,38 +78,46 @@ jobs:
                   ].join(" ");
                 })
                 .join("\n");
+            }
+
+            async function findPreviewUrlFromCloudflareComment() {
+              attempt += 1;
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              });
+
+              core.info(`Attempt ${attempt}: fetched ${comments.length} PR comments.`);
+              const recentCommentSummary = summarizeRecentComments(comments);
 
               if (recentCommentSummary) {
                 core.info(`Attempt ${attempt}: recent comments:\n${recentCommentSummary}`);
               }
 
               const cloudflareComments = comments
-                .filter((comment) => cloudflareBotLogins.has(comment.user.login))
+                .filter((comment) => comment.user.login === cloudflareBotLogin)
                 .sort((left, right) => new Date(right.updated_at) - new Date(left.updated_at));
 
               core.info(`Attempt ${attempt}: found ${cloudflareComments.length} Cloudflare comments.`);
 
               for (const comment of cloudflareComments) {
-                const body = comment.body ?? "";
-                const commitMatch = body.match(/<code>([0-9a-f]{7,40})<\/code>/i);
-                const latestCommit = commitMatch?.[1] ?? "";
-                const isCurrentHead = latestCommit && headSha.startsWith(latestCommit);
-                const isSuccessful = body.includes("Deploy successful");
-                const previewUrl = body.match(previewUrlPattern)?.[1] ?? "";
+                const parsed = parseCloudflareComment(comment);
 
                 core.info(
                   [
-                    `Attempt ${attempt}: inspect Cloudflare comment id=${comment.id}`,
-                    `updated=${comment.updated_at}`,
-                    `latestCommit=${latestCommit || "(not found)"}`,
-                    `isCurrentHead=${Boolean(isCurrentHead)}`,
-                    `isSuccessful=${isSuccessful}`,
-                    `previewUrl=${previewUrl || "(not found)"}`,
+                    `Attempt ${attempt}: inspect Cloudflare comment id=${parsed.id}`,
+                    `updated=${parsed.updatedAt}`,
+                    `latestCommit=${parsed.latestCommit || "(not found)"}`,
+                    `isCurrentHead=${parsed.isCurrentHead}`,
+                    `isSuccessful=${parsed.isSuccessful}`,
+                    `previewUrl=${parsed.previewUrl || "(not found)"}`,
                   ].join(" "),
                 );
 
-                if (isCurrentHead && isSuccessful && previewUrl) {
-                  return previewUrl;
+                if (parsed.isCurrentHead && parsed.isSuccessful && parsed.previewUrl) {
+                  return parsed.previewUrl;
                 }
               }
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Vite+ を中心に、React、Tailwind CSS、Radix Colors、Motion.dev、Jotai �
 - State: Jotai
 - Format / lint: Oxfmt / Oxlint / Stylelint
 - Component catalog: Storybook
-- Deploy: Void / Cloudflare
+- Deploy: Cloudflare Pages
 - Environment: Nix + direnv
 
 ## 開発

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,7 +114,7 @@ content は component に直接埋め込まない。section copy は `content/` 
 
 local build は `vp build`。CI も同じ command を使う。
 
-deploy は `vp run deploy` から `void deploy` を呼ぶ。Void が利用できない場合だけ Wrangler を fallback として検討するが、default path にはしない。
+deploy は Cloudflare Pages の Git integration を使う。Cloudflare Pages 側の build command は `vp build`、build output directory は `dist` にする。
 
 ## Naming
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -18,6 +18,8 @@ vp build
 
 `pnpm`, `vite`, `vitest`, `oxlint`, `oxfmt` を直接主導線にしない。Vite+ が持っている機能は Vite+ から使う。
 
+deploy は Cloudflare Pages の Git integration に委譲する。Cloudflare Pages 側では build command を `vp build`、build output directory を `dist` に設定する。
+
 ## TypeScript
 
 `tsconfig.json` は `@tsconfig/strictest` と `@tsconfig/node24` を基礎にする。

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@
 - Figma: [../.koutyuke/figma-design.md](../.koutyuke/figma-design.md)
 - 旧プロジェクト: `/Users/kousuke/Desktop/projects/koutyuke/old-koutyuke.dev`
 - Vite+: <https://viteplus.dev/>
-- Void: <https://void.cloud/>
+- Cloudflare Pages: <https://developers.cloudflare.com/pages/>
 
 ## ドキュメントの扱い
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "css:lint": "stylelint \"src/**/*.css\"",
     "css:lint:fix": "stylelint \"src/**/*.css\" --fix",
-    "deploy": "void deploy",
     "prepare": "if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then vp exec lefthook install; else echo 'skip lefthook install: not a git repository'; fi",
     "storybook": "storybook build",
     "storybook:dev": "storybook dev -p 6006 --no-version-updates --no-open"


### PR DESCRIPTION
## Summary

Cloudflare Pages への deploy 前提に合わせて project documentation と script を整理し、PR preview に対して Lighthouse を自動実行する GitHub Actions workflow を追加する。

## Background

deploy path を Void から Cloudflare Pages の Git integration に寄せるため、repository 内の deploy 記述と package script の実態を揃える必要がある。

また、preview deploy 後の表示品質を PR 上で継続的に確認できるようにする。

## Change Details

- Cloudflare Pages の preview URL を PR comment から取得し、Lighthouse を実行する `Lighthouse Preview` workflow を追加
- Lighthouse の JSON / HTML report を artifact として upload し、PR comment に score と主要 metric を投稿
- deploy documentation を Cloudflare Pages の Git integration 前提に更新
- `package.json` から Void deploy script を削除
- CodeRabbit の high-level summary comment を無効化

## Impact Area

- GitHub Actions の PR workflow
- Cloudflare Pages preview deploy 後の PR comment
- deploy 手順に関する documentation
- `package.json` の npm scripts

## Testing

- PR 上の GitHub Actions で `Lighthouse Preview` workflow を確認する
- Cloudflare Pages bot comment から preview URL を取得できることを確認する
- Lighthouse report artifact と PR comment が生成されることを確認する

## Related Issue

- closed #2 

## Notes

- workflow は fork からの PR では実行しない
- Cloudflare Pages 側の build command は `vp build`、build output directory は `dist` を前提にする
