### PR TITLE
docs(app): update README and add license

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,12 @@
 -
 -
 
+## Related Issue
+
+<!-- 関連するIssueを列強する -->
+
+- closed #
+
 ## Impact Area
 
 <!-- 影響しそうな機能、画面、API、DBなどを書く -->

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 koutyuke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,63 @@
-# koutyuke.dev
+<div align="center">
 
-`koutyuke.dev` は、1 ページで自分の輪郭を伝えるための personal portfolio site です。
+  <h1><img src="https://raw.githubusercontent.com/koutyuke/koutyuke/main/icons/icon.svg" width="32" align="center" alt="My Icon" /> koutyuke.dev</h1>
 
-Vite+ を中心に、React、Tailwind CSS、Radix Colors、Motion.dev、Jotai を組み合わせます。見た目は Figma を起点にしつつ、実装は component と state を薄く保ち、floating navigation と theme switching を気持ちよく動かすことを重視します。
+  <p>
+    1 page personal portfolio for showing who I am, what I build, and where to find me.
+  </p>
 
-## スタック
+  <p>
+    <a href="https://koutyuke.dev"><strong>koutyuke.dev</strong></a>
+    &nbsp;&bull;&nbsp;
+    <a href="./docs/README.md">Docs</a>
+    &nbsp;&bull;&nbsp;
+    <a href="./LICENSE">License</a>
+  </p>
 
-- Toolchain: Vite+ (`vp`)
-- Runtime: Node.js v24
-- Package manager: pnpm
-- UI: React
-- Styling: Tailwind CSS v4 + `@radix-ui/colors`
-- Motion: Motion.dev
-- State: Jotai
-- Format / lint: Oxfmt / Oxlint / Stylelint
-- Component catalog: Storybook
-- Deploy: Cloudflare Pages
-- Environment: Nix + direnv
+  <p>
+    <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-111111?style=flat" alt="MIT License"></a>
+    <img src="https://img.shields.io/badge/React-19-61dafb?style=flat&logo=react&logoColor=111111" alt="React 19">
+    <img src="https://img.shields.io/badge/Tailwind_CSS-v4-38bdf8?style=flat&logo=tailwindcss&logoColor=ffffff" alt="Tailwind CSS v4">
+    <img src="https://img.shields.io/badge/Vite+-toolchain-646cff?style=flat&logo=vite&logoColor=ffffff" alt="Vite+">
+  </p>
 
-## 開発
+</div>
 
-`vp` は現時点では Nix 管理せず、各自の環境に install します。
+## About
+
+`koutyuke.dev` is a one-page personal portfolio site for presenting the shape of `koutyuke`.
+
+The UI is built around React components, styled with Tailwind CSS v4 and Radix Colors, and animated with Motion.dev. The floating navigation expands from a button into a menu with continuous motion. Theme switching supports `system | light | dark`, with state managed by Jotai and DOM synchronization isolated in `theme-sync.tsx`.
+
+## Highlights
+
+| Area                    | Detail                                                                 |
+| :---------------------- | :--------------------------------------------------------------------- |
+| **Single Page**         | Collects hero, about, footprints, contact, and footer into one page    |
+| **Floating Navigation** | Navigation that smoothly expands from a button into a menu             |
+| **Theme Switching**     | Supports `system \| light \| dark` and follows OS preferences          |
+| **Component First**     | Keeps UI reviewable through React components and Storybook             |
+| **Strict Tooling**      | Runs TypeScript strict, Oxlint, Oxfmt, Stylelint, and Vitest via Vite+ |
+
+## Stack
+
+| Layer           | Tools                                                    |
+| :-------------- | :------------------------------------------------------- |
+| Toolchain       | Vite+ (`vp`)                                             |
+| Runtime         | Node.js v24                                              |
+| Package manager | pnpm                                                     |
+| UI              | React                                                    |
+| Styling         | Tailwind CSS v4, `@radix-ui/colors`, `the-new-css-reset` |
+| Motion          | Motion.dev                                               |
+| State           | Jotai                                                    |
+| Test / Catalog  | Vitest, Storybook                                        |
+| Quality         | Oxfmt, Oxlint, Stylelint, Lefthook                       |
+| Environment     | Nix, direnv                                              |
+| Deploy          | Cloudflare Pages                                         |
+
+## Quick Start
+
+`node`, `pnpm`, `git`, and `nixfmt-rfc-style` are provided by the Nix shell. `vp` is not managed by Nix yet, so install it with the official installer.
 
 ```sh
 curl -fsSL https://vite.plus | bash
@@ -29,20 +66,45 @@ vp install
 vp dev
 ```
 
-検証は Vite+ に集約します。
+## Commands
 
-```sh
-vp check
-vp test
-vp run css:lint
-vp run storybook
-vp build
+Daily development tasks are routed through Vite+.
+
+| Command            | Description                       |
+| :----------------- | :-------------------------------- |
+| `vp dev`           | Start the development server      |
+| `vp check`         | Run format, lint, and type checks |
+| `vp test`          | Run tests                         |
+| `vp run css:lint`  | Lint CSS with Stylelint           |
+| `vp run storybook` | Build Storybook for production    |
+| `vp build`         | Create a production build         |
+| `vp run deploy`    | Deploy to Cloudflare Pages        |
+
+## Project Map
+
+```text
+src/
+├── app/                         # application shell
+├── components/                  # shared presentational components
+├── content/                     # profile and footprint content
+├── features/
+│   ├── floating-navigation/     # navigation state, motion, panels
+│   └── theme/                   # theme state and DOM sync
+├── lib/                         # small shared utilities
+├── sections/                    # page sections
+└── styles/                      # global CSS and Tailwind theme
 ```
 
-## ドキュメント
+## Documentation
 
-- [docs/README.md](./docs/README.md): ドキュメントの入口
-- [docs/DESIGN.md](./docs/DESIGN.md): ビジュアル、motion、theme の方針
-- [docs/FRONTEND.md](./docs/FRONTEND.md): frontend 実装と toolchain
-- [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md): 構成、責務、data flow、coding rules
-- [docs/presentational-container-pattern.md](./docs/presentational-container-pattern.md): Presenter / Container Pattern の責務、依存方向、フォーム設計指針
+| Document                                                                               | Description                                                        |
+| :------------------------------------------------------------------------------------- | :----------------------------------------------------------------- |
+| [docs/README.md](./docs/README.md)                                                     | Documentation index                                                |
+| [docs/DESIGN.md](./docs/DESIGN.md)                                                     | Visual design, theme, motion, and accessibility principles         |
+| [docs/FRONTEND.md](./docs/FRONTEND.md)                                                 | Frontend implementation and toolchain notes                        |
+| [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)                                         | Directory structure, data flow, and coding rules                   |
+| [docs/presentational-container-pattern.md](./docs/presentational-container-pattern.md) | Presenter / Container Pattern responsibilities and dependency flow |
+
+## License
+
+MIT License. See [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
## Summary

README を portfolio site の入口として再構成し、repository の利用条件を示す MIT License を追加します。

## Background

portfolio site の目的、stack、主要 command、関連 documentation への導線を README から把握できる状態にするためです。

- closes #6

## Change Details

- README に概要、highlight、stack、quick start、commands、project map、documentation、license を整理
- repository root に MIT License file を追加
- docs と license への導線を README から辿れるように更新

## Impact Area

README と LICENSE の documentation のみです。runtime code、API、DB、deploy 設定への影響はありません。

## Testing

未実施です。変更範囲が documentation と license file のみであり、実行 code への変更はありません。

## Notes

なし。