### PR TITLE
fix(actions): run Lighthouse after preview deploy

### DIFF
--- a/.github/workflows/lighthouse-preview.yml
+++ b/.github/workflows/lighthouse-preview.yml
@@ -1,26 +1,27 @@
 name: Lighthouse Preview
 
 on:
-  pull_request:
-    types:
-      - opened
-      - ready_for_review
-      - reopened
-      - synchronize
+  deployment_status:
 
 concurrency:
-  group: lighthouse-preview-${{ github.event.pull_request.number }}
+  group: lighthouse-preview-${{ github.event.deployment.ref || github.event.deployment.sha }}
   cancel-in-progress: true
 
 permissions:
   contents: read
+  deployments: read
   issues: write
   pull-requests: write
 
 jobs:
   lighthouse:
     name: Lighthouse preview
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      github.event.deployment_status.state == 'success' &&
+      (
+        contains(github.event.deployment_status.environment_url, '.pages.dev') ||
+        contains(github.event.deployment_status.target_url, '.pages.dev')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -30,114 +31,53 @@ jobs:
         with:
           node-version: 24
 
-      - name: Find Cloudflare Pages preview URL
+      - name: Resolve preview deployment
         id: preview
         uses: actions/github-script@v7
         with:
           script: |
             const {owner, repo} = context.repo;
-            const pullRequest = context.payload.pull_request;
-            const headSha = pullRequest.head.sha;
-            const issue_number = pullRequest.number;
-            const cloudflareBotLogin = "cloudflare-workers-and-pages[bot]";
-            const previewUrlPattern =
-              /<strong>Preview URL:<\/strong><\/td><td>[\s\S]*?<a href=['"]([^'"]+\.pages\.dev)['"]/i;
-            const deadline = Date.now() + 10 * 60 * 1000;
-            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-            let attempt = 0;
+            const deployment = context.payload.deployment;
+            const deploymentStatus = context.payload.deployment_status;
+            const headSha = deployment.sha;
+            const previewUrl = [
+              deploymentStatus.environment_url,
+              deploymentStatus.target_url,
+            ].find((url) => url?.includes(".pages.dev"));
 
-            core.info(`Looking for Cloudflare Pages preview comment on PR #${issue_number}.`);
-            core.info(`Expected head SHA: ${headSha}`);
-            core.info(`Expected bot login: ${cloudflareBotLogin}`);
-
-            function parseCloudflareComment(comment) {
-              const body = comment.body ?? "";
-              const commitMatch = body.match(/<code>([0-9a-f]{7,40})<\/code>/i);
-              const latestCommit = commitMatch?.[1] ?? "";
-
-              return {
-                id: comment.id,
-                updatedAt: comment.updated_at,
-                latestCommit,
-                isCurrentHead: Boolean(latestCommit && headSha.startsWith(latestCommit)),
-                isSuccessful: body.includes("Deploy successful"),
-                previewUrl: body.match(previewUrlPattern)?.[1] ?? "",
-              };
+            if (!previewUrl) {
+              core.setFailed("Deployment status does not include a Cloudflare Pages preview URL.");
+              return;
             }
 
-            function summarizeRecentComments(comments) {
-              return comments
-                .slice(-10)
-                .map((comment) => {
-                  const hasPagesUrl = (comment.body ?? "").includes(".pages.dev");
-                  return [
-                    `id=${comment.id}`,
-                    `author=${comment.user?.login}`,
-                    `updated=${comment.updated_at}`,
-                    `hasPagesUrl=${hasPagesUrl}`,
-                  ].join(" ");
-                })
-                .join("\n");
-            }
+            core.info(`Deployment SHA: ${headSha}`);
+            core.info(`Deployment environment: ${deployment.environment}`);
+            core.info(`Preview URL: ${previewUrl}`);
 
-            async function findPreviewUrlFromCloudflareComment() {
-              attempt += 1;
-              const comments = await github.paginate(github.rest.issues.listComments, {
+            const associatedPullRequests = await github.paginate(
+              github.rest.repos.listPullRequestsAssociatedWithCommit,
+              {
                 owner,
                 repo,
-                issue_number,
+                commit_sha: headSha,
                 per_page: 100,
-              });
+              },
+            );
 
-              core.info(`Attempt ${attempt}: fetched ${comments.length} PR comments.`);
-              const recentCommentSummary = summarizeRecentComments(comments);
+            const pullRequest = associatedPullRequests
+              .filter((candidate) => candidate.head.repo?.full_name === `${owner}/${repo}`)
+              .filter((candidate) => candidate.state === "open")
+              .find((candidate) => candidate.head.sha === headSha);
 
-              if (recentCommentSummary) {
-                core.info(`Attempt ${attempt}: recent comments:\n${recentCommentSummary}`);
-              }
-
-              const cloudflareComments = comments
-                .filter((comment) => comment.user?.login === cloudflareBotLogin)
-                .sort((left, right) => new Date(right.updated_at) - new Date(left.updated_at));
-
-              core.info(`Attempt ${attempt}: found ${cloudflareComments.length} Cloudflare comments.`);
-
-              for (const comment of cloudflareComments) {
-                const parsed = parseCloudflareComment(comment);
-
-                core.info(
-                  [
-                    `Attempt ${attempt}: inspect Cloudflare comment id=${parsed.id}`,
-                    `updated=${parsed.updatedAt}`,
-                    `latestCommit=${parsed.latestCommit || "(not found)"}`,
-                    `isCurrentHead=${parsed.isCurrentHead}`,
-                    `isSuccessful=${parsed.isSuccessful}`,
-                    `previewUrl=${parsed.previewUrl || "(not found)"}`,
-                  ].join(" "),
-                );
-
-                if (parsed.isCurrentHead && parsed.isSuccessful && parsed.previewUrl) {
-                  return parsed.previewUrl;
-                }
-              }
-
-              return "";
+            if (!pullRequest) {
+              core.setFailed(`No open same-repository pull request is associated with deployment SHA ${headSha}.`);
+              return;
             }
 
-            while (Date.now() < deadline) {
-              const previewUrl = await findPreviewUrlFromCloudflareComment();
-
-              if (previewUrl) {
-                core.info(`Found preview URL: ${previewUrl}`);
-                core.setOutput("url", previewUrl);
-                return;
-              }
-
-              core.info("Cloudflare Pages comment is not ready yet. Waiting...");
-              await sleep(15 * 1000);
-            }
-
-            core.setFailed("Cloudflare Pages preview URL comment was not found within 10 minutes.");
+            core.info(`Resolved PR #${pullRequest.number}.`);
+            core.setOutput("sha", headSha);
+            core.setOutput("url", previewUrl);
+            core.setOutput("pr-number", String(pullRequest.number));
 
       - name: Run Lighthouse
         run: |
@@ -155,7 +95,7 @@ jobs:
         id: upload-report
         uses: actions/upload-artifact@v4
         with:
-          name: lighthouse-report-${{ github.event.pull_request.number }}
+          name: lighthouse-report-${{ steps.preview.outputs.pr-number }}
           path: .tmp/lighthouse/
           if-no-files-found: error
           retention-days: 14
@@ -164,12 +104,28 @@ jobs:
         uses: actions/github-script@v7
         env:
           ARTIFACT_URL: ${{ steps.upload-report.outputs.artifact-url }}
+          DEPLOYMENT_SHA: ${{ steps.preview.outputs.sha }}
+          PR_NUMBER: ${{ steps.preview.outputs.pr-number }}
           PREVIEW_URL: ${{ steps.preview.outputs.url }}
         with:
           script: |
             const fs = require("node:fs");
             const {owner, repo} = context.repo;
-            const issue_number = context.payload.pull_request.number;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const deploymentSha = process.env.DEPLOYMENT_SHA;
+            const {data: pullRequest} = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: issue_number,
+            });
+
+            if (pullRequest.head.sha !== deploymentSha) {
+              core.warning(
+                `Skip Lighthouse comment because PR head changed from ${deploymentSha} to ${pullRequest.head.sha}.`,
+              );
+              return;
+            }
+
             const report = JSON.parse(
               fs.readFileSync(".tmp/lighthouse/report.report.json", "utf8"),
             );

--- a/.github/workflows/lighthouse-preview.yml
+++ b/.github/workflows/lighthouse-preview.yml
@@ -1,27 +1,27 @@
 name: Lighthouse Preview
 
 on:
-  deployment_status:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
 
 concurrency:
-  group: lighthouse-preview-${{ github.event.deployment.ref || github.event.deployment.sha }}
+  group: lighthouse-preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
+  checks: read
   contents: read
-  deployments: read
   issues: write
   pull-requests: write
 
 jobs:
   lighthouse:
     name: Lighthouse preview
-    if: |
-      github.event.deployment_status.state == 'success' &&
-      (
-        contains(github.event.deployment_status.environment_url, '.pages.dev') ||
-        contains(github.event.deployment_status.target_url, '.pages.dev')
-      )
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -31,53 +31,88 @@ jobs:
         with:
           node-version: 24
 
-      - name: Resolve preview deployment
+      - name: Find Cloudflare Pages preview URL
         id: preview
         uses: actions/github-script@v7
         with:
           script: |
             const {owner, repo} = context.repo;
-            const deployment = context.payload.deployment;
-            const deploymentStatus = context.payload.deployment_status;
-            const headSha = deployment.sha;
-            const previewUrl = [
-              deploymentStatus.environment_url,
-              deploymentStatus.target_url,
-            ].find((url) => url?.includes(".pages.dev"));
+            const pullRequest = context.payload.pull_request;
+            const headSha = pullRequest.head.sha;
+            const previewUrlPattern =
+              /<strong>Preview URL:<\/strong><\/td><td>[\s\S]*?<a href=['"]([^'"]+\.pages\.dev)['"]/i;
+            const deadline = Date.now() + 10 * 60 * 1000;
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            let attempt = 0;
 
-            if (!previewUrl) {
-              core.setFailed("Deployment status does not include a Cloudflare Pages preview URL.");
-              return;
+            core.info(`Waiting for Cloudflare Pages check run on PR #${pullRequest.number}.`);
+            core.info(`Expected head SHA: ${headSha}`);
+
+            function parsePreviewUrl(checkRun) {
+              return checkRun.output?.summary?.match(previewUrlPattern)?.[1] ?? "";
             }
 
-            core.info(`Deployment SHA: ${headSha}`);
-            core.info(`Deployment environment: ${deployment.environment}`);
-            core.info(`Preview URL: ${previewUrl}`);
-
-            const associatedPullRequests = await github.paginate(
-              github.rest.repos.listPullRequestsAssociatedWithCommit,
-              {
+            async function findPreviewUrlFromCheckRun() {
+              attempt += 1;
+              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
                 owner,
                 repo,
-                commit_sha: headSha,
+                ref: headSha,
+                check_name: "Cloudflare Pages",
                 per_page: 100,
-              },
-            );
+              });
 
-            const pullRequest = associatedPullRequests
-              .filter((candidate) => candidate.head.repo?.full_name === `${owner}/${repo}`)
-              .filter((candidate) => candidate.state === "open")
-              .find((candidate) => candidate.head.sha === headSha);
+              const cloudflareCheckRuns = checkRuns
+                .filter((checkRun) => checkRun.app?.slug === "cloudflare-workers-and-pages")
+                .sort((left, right) => new Date(right.completed_at ?? right.started_at ?? 0) - new Date(left.completed_at ?? left.started_at ?? 0));
 
-            if (!pullRequest) {
-              core.setFailed(`No open same-repository pull request is associated with deployment SHA ${headSha}.`);
-              return;
+              core.info(`Attempt ${attempt}: found ${cloudflareCheckRuns.length} Cloudflare Pages check runs.`);
+
+              for (const checkRun of cloudflareCheckRuns) {
+                const previewUrl = parsePreviewUrl(checkRun);
+
+                core.info(
+                  [
+                    `Attempt ${attempt}: inspect check_run id=${checkRun.id}`,
+                    `status=${checkRun.status}`,
+                    `conclusion=${checkRun.conclusion ?? "(none)"}`,
+                    `previewUrl=${previewUrl || "(not found)"}`,
+                  ].join(" "),
+                );
+
+                if (checkRun.status !== "completed") {
+                  continue;
+                }
+
+                if (checkRun.conclusion !== "success") {
+                  throw new Error(`Cloudflare Pages check run completed with conclusion: ${checkRun.conclusion}.`);
+                }
+
+                if (previewUrl) {
+                  return previewUrl;
+                }
+              }
+
+              return "";
             }
 
-            core.info(`Resolved PR #${pullRequest.number}.`);
+            while (Date.now() < deadline) {
+              const previewUrl = await findPreviewUrlFromCheckRun();
+
+              if (previewUrl) {
+                core.info(`Found preview URL: ${previewUrl}`);
+                core.setOutput("url", previewUrl);
+                core.setOutput("pr-number", String(pullRequest.number));
+                core.setOutput("sha", headSha);
+                return;
+              }
+
+              core.info("Cloudflare Pages check run is not ready yet. Waiting...");
+              await sleep(15 * 1000);
+            }
+
+            core.setFailed("Cloudflare Pages preview URL was not found within 10 minutes.");
             core.setOutput("sha", headSha);
-            core.setOutput("url", previewUrl);
-            core.setOutput("pr-number", String(pullRequest.number));
 
       - name: Run Lighthouse
         run: |


### PR DESCRIPTION
## Summary

Cloudflare Pages preview の完了を待ってから Lighthouse を実行するように、preview URL の取得元を PR comment から Cloudflare Pages check run に変更しました。

## Background

初回 PR open 時は、Lighthouse workflow が Cloudflare Pages の preview comment 作成より先に起動し、preview URL を取得できない race が発生していました。

当初は `deployment_status` 起点へ変更しましたが、Cloudflare Pages はこの repository では GitHub Deployment ではなく `cloudflare-workers-and-pages` app の check run として preview 結果を通知していました。そのため `pull_request` trigger は維持し、Cloudflare Pages check run の完了を polling する方式に変更しています。

## Change Details

- `pull_request` trigger を維持し、PR 作成・更新時に Lighthouse workflow を起動する
- Cloudflare Pages の check run が完了するまで待ち、`output.summary` から `.pages.dev` preview URL を取得する
- PR comment の HTML parsing 依存を廃止する
- コメント投稿前に PR head SHA を再確認し、古い commit の結果でコメントを上書きしない

## Related Issue

- closed #15

## Impact Area

GitHub Actions の Lighthouse preview workflow のみです。アプリケーション runtime には影響しません。

## Testing

- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/lighthouse-preview.yml`
- `git diff --check`
- PR #16 への追加 push 後、`Lighthouse Preview` workflow が `pull_request` event で起動することを確認

## Notes

Cloudflare Pages の check run が `success` 以外で完了した場合は、Lighthouse を実行せず workflow を失敗させます。
