### PR TITLE
refactor(web): align coding style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-## 基本方針
+## Basic Policy
 
 - 日本語で対応する。
 - 技術用語、package 名、file path、command、code identifier は原語のまま書く。
@@ -8,7 +8,7 @@
 - 不確かな仕様、依存関係、外部サービスの挙動は確認してから扱う。
 - 変更後は、変更内容に見合う検証を実行し、実施した検証と未実施の検証を分けて報告する。
 
-## プロジェクト概要
+## Project Overview
 
 この repository は `koutyuke.dev` の personal portfolio site である。
 
@@ -29,11 +29,10 @@
 - Storybook build: `vp run sb:build`
 - production build: `vp build`
 - CSS lint: `vp run css:lint`
-- deploy: `vp run deploy`
 
 直接 `pnpm`, `vite`, `vitest`, `oxlint`, `oxfmt` を主導線にしない。Vite+ が wrap している tool は Vite+ 経由で使う。
 
-## 依存関係
+## Dependencies
 
 - runtime は Node.js v24。
 - package manager は pnpm。
@@ -41,7 +40,7 @@
 - `vp` はまだ Nix 管理していないため、各 developer が公式 installer で用意する。
 - 一時的な CLI が必要な場合は、永続 install ではなく `nix shell` または `vp dlx` を優先する。
 
-## コード規約
+## Coding Rules
 
 - 実装 file / directory は小文字 kebab-case にする。
 - 例外は `README.md`, `AGENTS.md`, `DESIGN.md` など、慣習または明示指定された documentation file に限る。
@@ -73,16 +72,9 @@
 
 環境構築だけの一時メモを `docs/` に残さない。方針が変わった場合は、該当する恒久ドキュメントへ反映する。
 
-## Git Hook / CI
-
-- Git hook は Lefthook を使う。
-- pre-commit は `vp staged` と `vp run css:lint` を実行する。
-- pre-push は `vp build` を実行する。
-- CI は `vp install`, `vp check`, `vp test`, `vp run sb:build`, `vp build` を実行する。
-
 ## Safety
 
 - secret、token、credential を hardcode しない。
 - 不要な依存関係を追加しない。
 - user が明示していない破壊的操作をしない。
-- Codex が生成した一時成果物、`dist/`, `storybook-static/`, `.tmp/`, `result` は、検証後に不要なら削除する。
+- Codex が生成した **git追跡外の一時成果物**、( `.tmp/`, `result`) は、検証後に不要なら削除する。

--- a/README.md
+++ b/README.md
@@ -84,15 +84,22 @@ Daily development tasks are routed through Vite+.
 
 ```text
 src/
-├── app/                         # application shell
-├── components/                  # shared presentational components
-├── content/                     # profile and footprint content
+├── app/                         # application shell and global styles
+├── entities/                    # domain data and entity UI
+│   ├── footprint/               # footprint content model
+│   └── profile/                 # profile model and social links UI
 ├── features/
-│   ├── floating-navigation/     # navigation state, motion, panels
 │   └── theme/                   # theme state and DOM sync
-├── lib/                         # small shared utilities
-├── sections/                    # page sections
-└── styles/                      # global CSS and Tailwind theme
+├── pages/
+│   └── home/                    # home page composition
+├── shared/                      # shared UI primitives and utilities
+└── widgets/                     # page sections and floating navigation
+    ├── about/
+    ├── contact/
+    ├── floating-navigation/
+    ├── footer/
+    ├── footprints/
+    └── hero/
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 
   <p>
     <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-111111?style=flat" alt="MIT License"></a>
-    <img src="https://img.shields.io/badge/React-19-61dafb?style=flat&logo=react&logoColor=111111" alt="React 19">
-    <img src="https://img.shields.io/badge/Tailwind_CSS-v4-38bdf8?style=flat&logo=tailwindcss&logoColor=ffffff" alt="Tailwind CSS v4">
-    <img src="https://img.shields.io/badge/Vite+-toolchain-646cff?style=flat&logo=vite&logoColor=ffffff" alt="Vite+">
+    <a href="https://react.dev/"><img src="https://img.shields.io/badge/React-19-61dafb?style=flat&logo=react&logoColor=111111" alt="React 19"></a>
+    <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwind_CSS-v4-38bdf8?style=flat&logo=tailwindcss&logoColor=ffffff" alt="Tailwind CSS v4"></a>
+    <a href="https://viteplus.dev/"><img src="https://img.shields.io/badge/Vite+-toolchain-646cff?style=flat&logo=vite&logoColor=ffffff" alt="Vite+"></a>
   </p>
 
 </div>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,6 +177,7 @@ ARCHITECTURE.md
 - `noUncheckedIndexedAccess` を前提に、array / object index access は undefined を考慮する。
 - `noPropertyAccessFromIndexSignature` を前提に、index signature 由来の property は bracket access にする。
 - test utilities は `vite-plus/test` から import する。
+- component、hook、helper の関数定義は arrow function に統一する。
 
 ### React
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -178,6 +178,7 @@ ARCHITECTURE.md
 - `noPropertyAccessFromIndexSignature` を前提に、index signature 由来の property は bracket access にする。
 - test utilities は `vite-plus/test` から import する。
 - component、hook、helper の関数定義は arrow function に統一する。
+- `if` / `else` / `for` / `while` などの block statement は必ず `{}` を使う。
 
 ### React
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -207,6 +207,7 @@ Oxfmt の import sort に従う。
 4. project / relative import
 
 type import は同じ group 内で value import の後に置く。
+`import { type Foo } from "foo"` の inline type import は使わず、value import と type import を別 import declaration に分ける。
 
 ```ts
 import { z } from "zod";

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -40,6 +40,7 @@ React は routing のためではなく component boundary のために使う。
 - shared helper は `shared/lib/` に置く。
 - component 名は PascalCase、file 名は kebab-case にする。
 - component、hook、helper の関数定義は arrow function に統一し、`function` declaration は使わない。
+- `if` / `else` / `for` / `while` などの block statement は必ず `{}` を使う。
 
 ## State
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -39,6 +39,7 @@ React は routing のためではなく component boundary のために使う。
 - domain data と domain UI は `entities/` に置く。
 - shared helper は `shared/lib/` に置く。
 - component 名は PascalCase、file 名は kebab-case にする。
+- component、hook、helper の関数定義は arrow function に統一し、`function` declaration は使わない。
 
 ## State
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -78,6 +78,7 @@ Oxfmt の import sort に従う。
 4. project / relative import
 
 type import は同じ group 内で value import の後に置く。
+`import { type Foo } from "foo"` の inline type import は使わず、value import と type import を別 import declaration に分ける。
 
 ```ts
 import { z } from "zod";

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,11 +1,11 @@
 import { HomePage } from "../pages/home";
 import { FloatingNavigation } from "../widgets/floating-navigation";
 
-export function App() {
+export const App = () => {
   return (
     <>
       <HomePage />
       <FloatingNavigation />
     </>
   );
-}
+};

--- a/src/entities/profile/ui/social-links/social-links.tsx
+++ b/src/entities/profile/ui/social-links/social-links.tsx
@@ -26,7 +26,7 @@ const socialLinks = [
   },
 ];
 
-export function SocialLinks({ className, showLabel = true }: SocialLinksProps) {
+export const SocialLinks = ({ className, showLabel = true }: SocialLinksProps) => {
   return (
     <div
       aria-label="Social links"
@@ -52,4 +52,4 @@ export function SocialLinks({ className, showLabel = true }: SocialLinksProps) {
       })}
     </div>
   );
-}
+};

--- a/src/features/theme/lib/theme.ts
+++ b/src/features/theme/lib/theme.ts
@@ -1,14 +1,14 @@
 export type ResolvedTheme = "light" | "dark";
 export type ThemeMode = "system" | ResolvedTheme;
 
-export function getSystemTheme(): ResolvedTheme {
+export const getSystemTheme = (): ResolvedTheme => {
   if (typeof window === "undefined") {
     return "light";
   }
 
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-}
+};
 
-export function resolveTheme(theme: ThemeMode, systemTheme: ResolvedTheme): ResolvedTheme {
+export const resolveTheme = (theme: ThemeMode, systemTheme: ResolvedTheme): ResolvedTheme => {
   return theme === "system" ? systemTheme : theme;
-}
+};

--- a/src/features/theme/model/theme-atoms.ts
+++ b/src/features/theme/model/theme-atoms.ts
@@ -2,7 +2,8 @@ import { atom } from "jotai";
 import { atomWithStorage, createJSONStorage } from "jotai/utils";
 
 import { storageKey } from "../../../shared/lib";
-import { getSystemTheme, resolveTheme, type ResolvedTheme, type ThemeMode } from "../lib/theme";
+import { getSystemTheme, resolveTheme } from "../lib/theme";
+import type { ResolvedTheme, ThemeMode } from "../lib/theme";
 
 const themeStorage = createJSONStorage<ThemeMode>(() => localStorage);
 

--- a/src/features/theme/model/use-theme.ts
+++ b/src/features/theme/model/use-theme.ts
@@ -3,9 +3,9 @@ import { useAtomValue } from "jotai";
 
 import { resolvedThemeAtom, themeModeAtom } from "./theme-atoms";
 
-export function useTheme() {
+export const useTheme = () => {
   const [theme, setTheme] = useAtom(themeModeAtom);
   const resolvedTheme = useAtomValue(resolvedThemeAtom);
 
   return { resolvedTheme, setTheme, theme };
-}
+};

--- a/src/features/theme/ui/theme-sync.tsx
+++ b/src/features/theme/ui/theme-sync.tsx
@@ -3,7 +3,7 @@ import { useEffect, useLayoutEffect } from "react";
 
 import { resolvedThemeAtom, systemThemeAtom } from "../model/theme-atoms";
 
-export function ThemeSync() {
+export const ThemeSync = () => {
   const resolvedTheme = useAtomValue(resolvedThemeAtom);
   const [, setSystemTheme] = useAtom(systemThemeAtom);
 
@@ -31,4 +31,4 @@ export function ThemeSync() {
   }, [setSystemTheme]);
 
   return null;
-}
+};

--- a/src/pages/home/ui/home-page.fixtures.tsx
+++ b/src/pages/home/ui/home-page.fixtures.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps } from "react";
 
 import { cn } from "../../../shared/lib";
-import { HomePageUI } from "./home-page.ui";
+import type { HomePageUI } from "./home-page.ui";
 
 type HomePageUISlots = ComponentProps<typeof HomePageUI>["slots"];
 

--- a/src/pages/home/ui/home-page.fixtures.tsx
+++ b/src/pages/home/ui/home-page.fixtures.tsx
@@ -10,7 +10,7 @@ type MockSectionProps = {
   minHeight?: string;
 };
 
-function MockSection({ label, minHeight = "min-h-64" }: MockSectionProps) {
+const MockSection = ({ label, minHeight = "min-h-64" }: MockSectionProps) => {
   return (
     <section
       className={cn(
@@ -30,7 +30,7 @@ function MockSection({ label, minHeight = "min-h-64" }: MockSectionProps) {
       {label}
     </section>
   );
-}
+};
 
 export const mockHomePageSlots = {
   HeroSection: <MockSection label="HeroSection slot" minHeight="min-h-screen" />,

--- a/src/pages/home/ui/home-page.tsx
+++ b/src/pages/home/ui/home-page.tsx
@@ -5,7 +5,7 @@ import { FootprintsSection } from "../../../widgets/footprints";
 import { HeroSection } from "../../../widgets/hero";
 import { HomePageUI } from "./home-page.ui";
 
-export function HomePage() {
+export const HomePage = () => {
   return (
     <HomePageUI
       slots={{
@@ -17,4 +17,4 @@ export function HomePage() {
       }}
     />
   );
-}
+};

--- a/src/pages/home/ui/home-page.ui.tsx
+++ b/src/pages/home/ui/home-page.ui.tsx
@@ -10,9 +10,9 @@ type HomePageUIProps = {
   };
 };
 
-export function HomePageUI({
+export const HomePageUI = ({
   slots: { AboutSection, ContactSection, FooterSection, FootprintsSection, HeroSection },
-}: HomePageUIProps) {
+}: HomePageUIProps) => {
   return (
     <>
       <main>
@@ -24,4 +24,4 @@ export function HomePageUI({
       {FooterSection}
     </>
   );
-}
+};

--- a/src/shared/lib/cn.ts
+++ b/src/shared/lib/cn.ts
@@ -1,5 +1,6 @@
-import { clsx, type ClassValue } from "clsx";
+import { clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
+import type { ClassValue } from "clsx";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/src/shared/lib/cn.ts
+++ b/src/shared/lib/cn.ts
@@ -2,6 +2,6 @@ import { clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import type { ClassValue } from "clsx";
 
-export function cn(...inputs: ClassValue[]) {
+export const cn = (...inputs: ClassValue[]) => {
   return twMerge(clsx(inputs));
-}
+};

--- a/src/shared/ui/icons/lucide-props.ts
+++ b/src/shared/ui/icons/lucide-props.ts
@@ -9,10 +9,10 @@ type ResolvedStrokeIconProps = {
   svgProps: IconSvgProps;
 };
 
-export function resolveStrokeIconProps(
+export const resolveStrokeIconProps = (
   { absoluteStrokeWidth, color = "currentColor", size = 24, strokeWidth, ...svgProps }: IconProps,
   defaultStrokeWidth: IconProps["strokeWidth"] = 2,
-): ResolvedStrokeIconProps {
+): ResolvedStrokeIconProps => {
   const resolvedStrokeWidth = strokeWidth ?? defaultStrokeWidth;
   const numericSize = typeof size === "number" ? size : Number.parseFloat(size);
   const numericStrokeWidth =
@@ -30,15 +30,15 @@ export function resolveStrokeIconProps(
     strokeWidth: scaledStrokeWidth,
     svgProps,
   };
-}
+};
 
-export function resolveFillIconProps({
+export const resolveFillIconProps = ({
   absoluteStrokeWidth: _absoluteStrokeWidth,
   color = "currentColor",
   size = 24,
   strokeWidth: _strokeWidth,
   ...svgProps
-}: IconProps) {
+}: IconProps) => {
   void _absoluteStrokeWidth;
   void _strokeWidth;
 
@@ -47,4 +47,4 @@ export function resolveFillIconProps({
     size,
     svgProps,
   };
-}
+};

--- a/src/shared/ui/section-divider/section-divider.tsx
+++ b/src/shared/ui/section-divider/section-divider.tsx
@@ -4,7 +4,7 @@ type SectionDividerProps = {
   className?: string;
 };
 
-export function SectionDivider({ className }: SectionDividerProps) {
+export const SectionDivider = ({ className }: SectionDividerProps) => {
   return (
     <div
       aria-hidden="true"
@@ -14,4 +14,4 @@ export function SectionDivider({ className }: SectionDividerProps) {
       )}
     />
   );
-}
+};

--- a/src/shared/ui/section-heading/section-heading.tsx
+++ b/src/shared/ui/section-heading/section-heading.tsx
@@ -7,7 +7,7 @@ type SectionHeadingProps = {
   title: string;
 };
 
-export function SectionHeading({ align = "start", eyebrow, id, title }: SectionHeadingProps) {
+export const SectionHeading = ({ align = "start", eyebrow, id, title }: SectionHeadingProps) => {
   return (
     <header className={cn("grid gap-1 pb-6", align === "center" ? "text-center" : "text-start")}>
       <h2 className="m-0 font-handwritten text-4xl leading-[1.05] text-slate-12" id={id}>
@@ -16,4 +16,4 @@ export function SectionHeading({ align = "start", eyebrow, id, title }: SectionH
       {eyebrow ? <p className="m-0 text-xs font-medium text-slate-10">{eyebrow}</p> : null}
     </header>
   );
-}
+};

--- a/src/shared/ui/tag-list/tag-list.tsx
+++ b/src/shared/ui/tag-list/tag-list.tsx
@@ -5,7 +5,7 @@ type TagListProps = {
   tags: readonly string[];
 };
 
-export function TagList({ className, tags }: TagListProps) {
+export const TagList = ({ className, tags }: TagListProps) => {
   return (
     <ul className={cn("m-0 flex list-none flex-wrap gap-2 p-0", className)}>
       {tags.map((tag) => (
@@ -18,4 +18,4 @@ export function TagList({ className, tags }: TagListProps) {
       ))}
     </ul>
   );
-}
+};

--- a/src/widgets/about/ui/about-section.tsx
+++ b/src/widgets/about/ui/about-section.tsx
@@ -1,6 +1,6 @@
 import { techStacks } from "../../../entities/profile";
 import { AboutSectionUI } from "./about-section.ui";
 
-export function AboutSection() {
+export const AboutSection = () => {
   return <AboutSectionUI techStacks={techStacks} />;
-}
+};

--- a/src/widgets/about/ui/about-section.ui.tsx
+++ b/src/widgets/about/ui/about-section.ui.tsx
@@ -9,7 +9,7 @@ type AboutSectionUIProps = {
   };
 };
 
-export function AboutSectionUI({ techStacks }: AboutSectionUIProps) {
+export const AboutSectionUI = ({ techStacks }: AboutSectionUIProps) => {
   return (
     <section
       aria-labelledby="about-title"
@@ -68,4 +68,4 @@ export function AboutSectionUI({ techStacks }: AboutSectionUIProps) {
       </div>
     </section>
   );
-}
+};

--- a/src/widgets/contact/ui/contact-section.tsx
+++ b/src/widgets/contact/ui/contact-section.tsx
@@ -1,5 +1,5 @@
 import { ContactSectionUI } from "./contact-section.ui";
 
-export function ContactSection() {
+export const ContactSection = () => {
   return <ContactSectionUI />;
-}
+};

--- a/src/widgets/contact/ui/contact-section.ui.tsx
+++ b/src/widgets/contact/ui/contact-section.ui.tsx
@@ -1,7 +1,7 @@
 import { SocialLinks } from "../../../entities/profile";
 import { SectionDivider } from "../../../shared/ui/section-divider";
 
-export function ContactSectionUI() {
+export const ContactSectionUI = () => {
   return (
     <section
       aria-labelledby="contact-title"
@@ -32,4 +32,4 @@ export function ContactSectionUI() {
       </div>
     </section>
   );
-}
+};

--- a/src/widgets/floating-navigation/ui/floating-navigation.test.tsx
+++ b/src/widgets/floating-navigation/ui/floating-navigation.test.tsx
@@ -31,13 +31,13 @@ afterEach(() => {
   localStorage.clear();
 });
 
-function renderFloatingNavigation() {
+const renderFloatingNavigation = () => {
   return render(
     <Provider>
       <FloatingNavigation />
     </Provider>,
   );
-}
+};
 
 test("opens from a compact floating button into a menu panel", async () => {
   const user = userEvent.setup();

--- a/src/widgets/floating-navigation/ui/floating-navigation.tsx
+++ b/src/widgets/floating-navigation/ui/floating-navigation.tsx
@@ -1,8 +1,8 @@
 import { useTheme } from "../../../features/theme";
 import { FloatingNavigationUI } from "./floating-navigation.ui";
 
-export function FloatingNavigation() {
+export const FloatingNavigation = () => {
   const { theme, setTheme: onThemeChange } = useTheme();
 
   return <FloatingNavigationUI actions={{ onThemeChange }} theme={theme} />;
-}
+};

--- a/src/widgets/floating-navigation/ui/floating-navigation.ui.tsx
+++ b/src/widgets/floating-navigation/ui/floating-navigation.ui.tsx
@@ -1,6 +1,7 @@
 import { MenuIcon } from "lucide-react";
 import { motion } from "motion/react";
-import { useCallback, useEffect, useId, useRef, useState, type KeyboardEvent } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
 
 import { cn } from "../../../shared/lib";
 import { AboutPanelUI } from "./panels/about-panel.ui";

--- a/src/widgets/floating-navigation/ui/floating-navigation.ui.tsx
+++ b/src/widgets/floating-navigation/ui/floating-navigation.ui.tsx
@@ -20,16 +20,16 @@ const focusableSelector = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(",");
 
-function getFocusableElements(container: HTMLElement) {
+const getFocusableElements = (container: HTMLElement) => {
   return Array.from(container.querySelectorAll<HTMLElement>(focusableSelector)).filter(
     (element) =>
       !element.hasAttribute("disabled") && element.getAttribute("aria-hidden") !== "true",
   );
-}
+};
 
-function isOpen(view: FloatingNavigationView) {
+const isOpen = (view: FloatingNavigationView) => {
   return view !== "closed";
-}
+};
 
 type FloatingNavigationUIProps = {
   actions: {

--- a/src/widgets/floating-navigation/ui/panels/about-panel.ui.tsx
+++ b/src/widgets/floating-navigation/ui/panels/about-panel.ui.tsx
@@ -10,7 +10,7 @@ type AboutPanelUIProps = {
   };
 };
 
-export function AboutPanelUI({ actions: { onBack } }: AboutPanelUIProps) {
+export const AboutPanelUI = ({ actions: { onBack } }: AboutPanelUIProps) => {
   return (
     <div className="flex size-full flex-col">
       <div className="flex flex-1 flex-col gap-2 p-1">
@@ -50,4 +50,4 @@ export function AboutPanelUI({ actions: { onBack } }: AboutPanelUIProps) {
       <PanelFooterAction type="back" onClick={onBack} />
     </div>
   );
-}
+};

--- a/src/widgets/floating-navigation/ui/panels/menu-panel.ui.tsx
+++ b/src/widgets/floating-navigation/ui/panels/menu-panel.ui.tsx
@@ -38,7 +38,9 @@ type MenuPanelUIProps = {
   };
 };
 
-export function MenuPanelUI({ actions: { onClose, onOpenAbout, onOpenTheme } }: MenuPanelUIProps) {
+export const MenuPanelUI = ({
+  actions: { onClose, onOpenAbout, onOpenTheme },
+}: MenuPanelUIProps) => {
   return (
     <div className="flex size-full flex-col">
       <PanelItem
@@ -121,4 +123,4 @@ export function MenuPanelUI({ actions: { onClose, onOpenAbout, onOpenTheme } }: 
       <PanelFooterAction type="close" onClick={onClose} />
     </div>
   );
-}
+};

--- a/src/widgets/floating-navigation/ui/panels/menu-panel.ui.tsx
+++ b/src/widgets/floating-navigation/ui/panels/menu-panel.ui.tsx
@@ -8,8 +8,8 @@ import {
   NotebookPen,
   Palette,
   User,
-  type LucideIcon,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 
 import { links } from "../../../../entities/profile";
 import { cn } from "../../../../shared/lib";

--- a/src/widgets/floating-navigation/ui/panels/parts.tsx
+++ b/src/widgets/floating-navigation/ui/panels/parts.tsx
@@ -43,9 +43,9 @@ export const PanelItem = <T extends PanelItemElement = "div">({
   );
 };
 
-export function PanelSeparator() {
+export const PanelSeparator = () => {
   return <div aria-hidden="true" className="m-1.5 h-px bg-slate-9" />;
-}
+};
 
 type PanelFooterActionProps = {
   type: "back" | "close";

--- a/src/widgets/floating-navigation/ui/panels/theme-panel.ui.tsx
+++ b/src/widgets/floating-navigation/ui/panels/theme-panel.ui.tsx
@@ -25,7 +25,7 @@ type ThemePanelUIProps = {
   };
 };
 
-export function ThemePanelUI({ actions: { onBack, onThemeChange }, theme }: ThemePanelUIProps) {
+export const ThemePanelUI = ({ actions: { onBack, onThemeChange }, theme }: ThemePanelUIProps) => {
   return (
     <div className="flex size-full flex-col">
       {themeOptions.map(({ icon: Icon, label, value }) => (
@@ -43,4 +43,4 @@ export function ThemePanelUI({ actions: { onBack, onThemeChange }, theme }: Them
       <PanelFooterAction type="back" onClick={onBack} />
     </div>
   );
-}
+};

--- a/src/widgets/floating-navigation/ui/panels/theme-panel.ui.tsx
+++ b/src/widgets/floating-navigation/ui/panels/theme-panel.ui.tsx
@@ -1,4 +1,5 @@
-import { Laptop, type LucideIcon, Moon, Sun } from "lucide-react";
+import { Laptop, Moon, Sun } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 
 import { AnimatedCheckIcon } from "../../../../shared/ui/icons";
 import { PanelFooterAction, PanelItem } from "./parts";

--- a/src/widgets/footer/ui/footer-section.tsx
+++ b/src/widgets/footer/ui/footer-section.tsx
@@ -1,5 +1,5 @@
 import { FooterSectionUI } from "./footer-section.ui";
 
-export function FooterSection() {
+export const FooterSection = () => {
   return <FooterSectionUI />;
-}
+};

--- a/src/widgets/footer/ui/footer-section.ui.tsx
+++ b/src/widgets/footer/ui/footer-section.ui.tsx
@@ -1,4 +1,4 @@
-export function FooterSectionUI() {
+export const FooterSectionUI = () => {
   return (
     <footer className="h-25 bg-slate-1 px-6">
       <div className="mx-auto flex h-full w-full max-w-160 items-center justify-between gap-4 text-center text-xs text-slate-11">
@@ -7,4 +7,4 @@ export function FooterSectionUI() {
       </div>
     </footer>
   );
-}
+};

--- a/src/widgets/footprints/ui/footprints-section.fixtures.ts
+++ b/src/widgets/footprints/ui/footprints-section.fixtures.ts
@@ -1,6 +1,6 @@
 import type { ComponentProps } from "react";
 
-import { FootprintsSectionUI } from "./footprints-section.ui";
+import type { FootprintsSectionUI } from "./footprints-section.ui";
 
 type FootprintsSectionUIItems = ComponentProps<typeof FootprintsSectionUI>["footprints"];
 

--- a/src/widgets/footprints/ui/footprints-section.tsx
+++ b/src/widgets/footprints/ui/footprints-section.tsx
@@ -1,6 +1,6 @@
 import { footprints } from "../../../entities/footprint";
 import { FootprintsSectionUI } from "./footprints-section.ui";
 
-export function FootprintsSection() {
+export const FootprintsSection = () => {
   return <FootprintsSectionUI footprints={footprints} />;
-}
+};

--- a/src/widgets/footprints/ui/footprints-section.ui.tsx
+++ b/src/widgets/footprints/ui/footprints-section.ui.tsx
@@ -6,7 +6,7 @@ type FootprintsSectionUIProps = {
   footprints: readonly Footprint[];
 };
 
-export function FootprintsSectionUI({ footprints }: FootprintsSectionUIProps) {
+export const FootprintsSectionUI = ({ footprints }: FootprintsSectionUIProps) => {
   return (
     <section
       aria-labelledby="footprints-title"
@@ -47,4 +47,4 @@ export function FootprintsSectionUI({ footprints }: FootprintsSectionUIProps) {
       </div>
     </section>
   );
-}
+};

--- a/src/widgets/hero/ui/hero-section.tsx
+++ b/src/widgets/hero/ui/hero-section.tsx
@@ -1,5 +1,5 @@
 import { HeroSectionUI } from "./hero-section.ui";
 
-export function HeroSection() {
+export const HeroSection = () => {
   return <HeroSectionUI />;
-}
+};

--- a/src/widgets/hero/ui/hero-section.ui.tsx
+++ b/src/widgets/hero/ui/hero-section.ui.tsx
@@ -3,7 +3,7 @@ import { ChevronDown } from "lucide-react";
 import { SocialLinks } from "../../../entities/profile";
 import { AsteriskIcon, KoutyukeIcon } from "../../../shared/ui/icons";
 
-export function HeroSectionUI() {
+export const HeroSectionUI = () => {
   return (
     <section
       aria-labelledby="hero-title"
@@ -57,4 +57,4 @@ export function HeroSectionUI() {
       </a>
     </section>
   );
-}
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,6 +71,7 @@ export default defineConfig({
       pedantic: "off",
     },
     rules: {
+      curly: ["error", "all"],
       eqeqeq: "error",
       "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
       "no-console": "warn",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,11 +72,16 @@ export default defineConfig({
     },
     rules: {
       eqeqeq: "error",
+      "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
       "no-console": "warn",
       "no-debugger": "error",
       "react/react-in-jsx-scope": "off",
       "react/jsx-no-useless-fragment": "warn",
       "react/self-closing-comp": "warn",
+      "typescript/consistent-type-imports": [
+        "error",
+        { fixStyle: "separate-type-imports", prefer: "type-imports" },
+      ],
     },
     options: {
       typeAware: true,


### PR DESCRIPTION
## Summary

coding style の揺れを抑えるため、関数定義・import・block statement の方針を整理し、静的検査で検出できる rule を追加します。

## Background

Issue #3 で扱っている coding style 統一の作業です。directory structure の整理は別 issue に分離し、この PR では style rule と自動検査可能な整備に集中します。

## Change Details

- React component などの関数定義を arrow function の宣言へ寄せる
- value import と type import を分離し、関連 documentation に方針を追記する
- `curly` rule を有効化し、block statement の `{}` 省略を検査対象にする

## Related Issue

- closed #3

## Impact Area

Web frontend の coding style、lint 設定、project documentation に影響します。runtime behavior の変更は意図していません。

## Testing

- `./node_modules/.bin/vp check`

## Notes

`vp` が global PATH になかったため、local binary 経由で同等の check を実行しました。
