### PR TITLE
improve(a11y): strengthen site accessibility baseline

### DIFF
--- a/src/shared/ui/section-heading/section-heading.tsx
+++ b/src/shared/ui/section-heading/section-heading.tsx
@@ -13,7 +13,7 @@ export const SectionHeading = ({ align = "start", eyebrow, id, title }: SectionH
       <h2 className="m-0 font-handwritten text-4xl leading-[1.05] text-slate-12" id={id}>
         {title}
       </h2>
-      {eyebrow ? <p className="m-0 text-xs font-medium text-slate-10">{eyebrow}</p> : null}
+      {eyebrow ? <p className="m-0 text-xs font-medium text-slate-11">{eyebrow}</p> : null}
     </header>
   );
 };

--- a/src/widgets/contact/ui/contact-section.ui.tsx
+++ b/src/widgets/contact/ui/contact-section.ui.tsx
@@ -13,7 +13,7 @@ export const ContactSectionUI = () => {
 
         <div className="flex flex-col items-center gap-6">
           <header className="relative grid gap-1 text-center">
-            <p className="m-0 font-handwritten text-xs text-slate-10">Let&apos;s Contact!</p>
+            <p className="m-0 font-handwritten text-xs text-slate-11">Let&apos;s Contact!</p>
             <h2
               className="m-0 font-handwritten text-4xl leading-[1.05] text-slate-12"
               id="contact-title"
@@ -22,7 +22,7 @@ export const ContactSectionUI = () => {
             </h2>
           </header>
 
-          <p className="text-center text-xs font-medium text-slate-10">
+          <p className="text-center text-xs font-medium text-slate-11">
             気軽にのぞいたり、声をかけたり
           </p>
           <SocialLinks />

--- a/src/widgets/floating-navigation/ui/floating-navigation.test.tsx
+++ b/src/widgets/floating-navigation/ui/floating-navigation.test.tsx
@@ -65,6 +65,22 @@ test("opens the theme panel and reports selected theme", async () => {
   expect(localStorage.getItem(storageKey.theme)).toBe(JSON.stringify("dark"));
 });
 
+test("exposes the selected theme state to assistive technology", async () => {
+  const user = userEvent.setup();
+
+  renderFloatingNavigation();
+
+  await user.click(screen.getByRole("button", { name: "Open navigation" }));
+  await user.click(screen.getByRole("button", { name: "Theme" }));
+
+  expect(screen.getByRole("button", { name: "System" }).getAttribute("aria-pressed")).toBe("true");
+  expect(screen.getByRole("button", { name: "Light" }).getAttribute("aria-pressed")).toBe("false");
+
+  await user.click(screen.getByRole("button", { name: "Dark" }));
+
+  expect(screen.getByRole("button", { name: "Dark" }).getAttribute("aria-pressed")).toBe("true");
+});
+
 test("moves focus into the active panel when switching panels", async () => {
   const user = userEvent.setup();
 

--- a/src/widgets/floating-navigation/ui/panels/parts.tsx
+++ b/src/widgets/floating-navigation/ui/panels/parts.tsx
@@ -29,7 +29,7 @@ export const PanelItem = <T extends PanelItemElement = "div">({
     <Component
       type={as === "button" ? "button" : undefined}
       className={cn(
-        "flex h-10 items-center gap-2.5 rounded-lg border border-transparent px-2 text-start text-base font-medium text-slate-12 transition hover:border-slate-6 hover:bg-slate-4 focus-visible:bg-slate-4 focus-visible:outline-none",
+        "flex h-10 items-center gap-2.5 rounded-lg border border-transparent px-2 text-start text-base font-medium text-slate-12 transition hover:border-slate-6 hover:bg-slate-4 focus-visible:bg-slate-4",
         as === "a" && "cursor-pointer",
         as === "button" && "cursor-pointer",
         className,
@@ -57,7 +57,7 @@ export const PanelFooterAction = ({ type, onClick }: PanelFooterActionProps): JS
   return (
     <button
       aria-label={type === "back" ? "戻る" : "閉じる"}
-      className="pointer-events-auto grid h-10 w-full cursor-pointer place-items-center rounded-lg border border-slate-7 bg-slate-4 text-slate-12 transition hover:bg-slate-5 focus-visible:bg-slate-5 focus-visible:outline-none"
+      className="pointer-events-auto grid h-10 w-full cursor-pointer place-items-center rounded-lg border border-slate-7 bg-slate-4 text-slate-12 transition hover:bg-slate-5 focus-visible:bg-slate-5"
       type="button"
       onClick={onClick}
     >

--- a/src/widgets/floating-navigation/ui/panels/theme-panel.ui.tsx
+++ b/src/widgets/floating-navigation/ui/panels/theme-panel.ui.tsx
@@ -32,9 +32,14 @@ export const ThemePanelUI = ({ actions: { onBack, onThemeChange }, theme }: Them
         <PanelItem
           key={value}
           as="button"
+          aria-pressed={theme === value}
           onClick={() => onThemeChange(value)}
           LeftContent={<Icon aria-hidden="true" className="size-6 shrink-0" />}
-          RightContent={theme === value ? <AnimatedCheckIcon className="size-5" /> : null}
+          RightContent={
+            theme === value ? (
+              <AnimatedCheckIcon aria-hidden="true" className="size-5" focusable="false" />
+            ) : null
+          }
         >
           {label}
         </PanelItem>

--- a/src/widgets/hero/ui/hero-section.test.tsx
+++ b/src/widgets/hero/ui/hero-section.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, test } from "vite-plus/test";
+
+import { HeroSectionUI } from "./hero-section.ui";
+
+afterEach(() => {
+  cleanup();
+});
+
+test("keeps visible scroll link text in its accessible name", () => {
+  render(<HeroSectionUI />);
+
+  expect(screen.getByRole("link", { name: "scroll down to about section" })).not.toBeNull();
+});

--- a/src/widgets/hero/ui/hero-section.ui.tsx
+++ b/src/widgets/hero/ui/hero-section.ui.tsx
@@ -48,7 +48,7 @@ export const HeroSectionUI = () => {
       </div>
 
       <a
-        aria-label="Scroll to about section"
+        aria-label="scroll down to about section"
         className="absolute bottom-20 left-1/2 inline-flex -translate-x-1/2 flex-col items-center gap-0.5 font-handwritten text-base leading-none text-slate-11 no-underline"
         href="#about"
       >


### PR DESCRIPTION
## Summary

site の accessibility baseline を改善しました。theme selection の選択状態、hero の scroll link、低コントラスト気味だった補助テキストを調整しています。

## Background

keyboard、screen reader、低視力環境でも personal portfolio site を扱いやすくするため、基本的な a11y の土台を整える必要があります。

## Change Details

- theme panel の各 option に `aria-pressed` を付与し、現在選択中の theme を assistive technology に伝えるようにした
- selected state の check icon を装飾として扱い、accessible name に不要な情報が混ざらないようにした
- floating navigation の focus-visible style で outline を消さず、focus indicator を維持するようにした
- hero の scroll link の accessible name に visible text を含め、name/label の不一致を解消した
- section/contact の補助テキストを `text-slate-11` に上げ、contrast を改善した
- theme selection と hero scroll link の a11y regression test を追加した

## Related Issue

- closes #10

## Impact Area

- Hero section
- Contact section
- Floating navigation / theme panel
- Accessibility semantics and focus visibility

## Testing

- `./node_modules/.bin/vp check`
- `./node_modules/.bin/vp test`

## Notes

- global PATH 上の `vp` は見つからなかったため、repository 内の `node_modules/.bin/vp` を直接実行しました。
